### PR TITLE
Add patch for Alliedvision Cameras with Xavier NX and Jetpack 5.0.2 (baseboard rev 1.5.x)

### DIFF
--- a/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
+++ b/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
@@ -1,9 +1,10 @@
 # Antmicro Baseboard Allied-Vision Camera Driver Setup Guide (Xavier NX, Jetpack 5.0.2)
 
 This guide documents the process for building and deploying the Allied Vision driver for the antmicro baseboard with the
-appropriate patch and configuration for your chosen camera setup. Whilst this guide is specifically for the xavier NX,
-the general process can be applied to other boards should you be interested in adding support for a board+version combo
-not provided by any of the existing patches.
+appropriate patch and configuration for your chosen camera setup. 
+
+Whilst this guide is specifically for the xavier NX, the general process can be applied to other boards should you be 
+interested in adding support for a board+version combo not provided by any of the existing patches.
 
 ## Prerequisites
 
@@ -42,8 +43,8 @@ to index 5 for this camera.
 
 The following configurations are provided by this patch:
 
-- **Antmicro**: The default, all 4 ports enabled at 2-lanes, use with any configuration of camera's and cables.
-- **Antmicro 4-Lane**: All 3 ports supporting 4-lanes enabled at full-width, J6 Left camera disabled (see note 2 above)
+- **Antmicro JNB**: The default, all 4 ports enabled at 2-lanes, use with any configuration of camera's and cables.
+- **Antmicro JNB 4-Lane**: All 3 ports supporting 4-lanes enabled at full-width, J6 Left camera disabled (see note 2 above)
 
 > Note 1. Not all cameras need to be present in order for a configuration to work at runtime. Unless there are other
 restrictions or limitations, the '`Antmicro`' configuration provided here should be suitable for *most*

--- a/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
+++ b/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
@@ -20,7 +20,7 @@ connection options, as well as the configuration information needed to specify t
 
 | **Connector Designation** | **I2C Mux Index** | **CSI Port Index** | **Max Lanes** | **CSI Serial Name** | **Single Cable?** |
 |:-------------------------:|:-----------------:|:------------------:|:-------------:|:-------------------:|:-----------------:|
-|  FFC #1 (J6) Left Camera  |         0         |          5         |       2       |       serial_g      |                   |
+|  FFC #1 (J6) Left Camera  |         0         |          6(5)      |       2       |       serial_g      |                   |
 |  FFC #1 (J6) Right Camera |         1         |          2         |       4       |       serial_e      |         x         |
 |  FFC #2 (J7) Right Camera |         2         |          0         |       4       |       serial_a      |         x         |
 |  FFC #2 (J7) Left Camera  |         3         |          4         |       4       |       serial_c      |                   |
@@ -33,6 +33,10 @@ the specification in the schematic.
 > Note 2. The Xavier NX can support a maximum of 12 total CSI lanes at once, even though the baseboard exposes a total of
 14 lanes at the camera connections. Keep in mind this limit when customising the configuration as it is not
 possible to run all cameras ports at their maximum supported lanes at once.
+
+> Note 3. The CSI lanes connecting the FFC #1 (J6) Left Camera to the xaiver NX are at CSI port index 6, but for
+bus-routing purposes the port definition inside 'tegra-capture-vi' and 'avt_csi2' in the device-tree should be set
+to index 5 for this camera.
 
 ### Included configurations
 

--- a/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
+++ b/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
@@ -1,0 +1,109 @@
+# Antmicro Baseboard Allied-Vision Camera Driver Setup Guide (Xavier NX, Jetpack 5.0.2)
+
+This guide documents the process for building and deploying the Allied Vision driver for the antmicro baseboard with the
+appropriate patch and configuration for your chosen camera setup. Whilst this guide is specifically for the xavier NX,
+the general process can be applied to other boards should you be interested in adding support for a board+version combo
+not provided by any of the existing patches.
+
+## Prerequisites
+
+- Antmicro Open Source Baseboard (rev 1.5.x)
+- NVIDIA Jetson Xavier NX (either dev or prod module), flashed with the stock JP 5.0.2 image and running on the baseboard.
+
+## Selecting Camera Configuration
+
+### Port layout and driver definitions
+
+The antmicro baseboard features the option to connect each Allied Vision camera to one of four MIPI CSI Ports, with two
+ports located on each of the two camera FFC Connectors on the baseboard. The following table shows the available
+connection options, as well as the configuration information needed to specify them in the patch:
+
+| **Connector Designation** | **I2C Mux Index** | **CSI Port Index** | **Max Lanes** | **CSI Serial Name** | **Single Cable?** |
+|:-------------------------:|:-----------------:|:------------------:|:-------------:|:-------------------:|:-----------------:|
+|  FFC #1 (J6) Left Camera  |         0         |          5         |       2       |       serial_g      |                   |
+|  FFC #1 (J6) Right Camera |         1         |          2         |       4       |       serial_e      |         x         |
+|  FFC #2 (J7) Right Camera |         2         |          0         |       4       |       serial_a      |         x         |
+|  FFC #2 (J7) Left Camera  |         3         |          4         |       4       |       serial_c      |                   |
+
+> Note 1. The [alvium adapter cables](https://github.com/antmicro/alvium-flexible-csi-adapter) that connect this board to
+the allied vision cameras are available in either a double-camera or single-camera output for each FFC connector.
+The single-camera flex cable always connects to the *Right Camera* of either FFC Connector. Connector names are per
+the specification in the schematic.
+
+> Note 2. The Xavier NX can support a maximum of 12 total CSI lanes at once, even though the baseboard exposes a total of
+14 lanes at the camera connections. Keep in mind this limit when customising the configuration as it is not
+possible to run all cameras ports at their maximum supported lanes at once.
+
+### Included configurations
+
+The following configurations are provided by this patch:
+
+- **Antmicro All**: The default, all 4 ports enabled at 2-lanes, use with any configuration of camera's and cables.
+- **Antmicro Dual J6**: 2x 2-lane cameras configured on J6, for use with the dual-alvium flex cable
+- **Antmicro Dual J7**: 2x 4-lane cameras configured on J7, for use with the dual-alvium flex cable
+- **Antmicro Dual Split**: 2x 4-lane cameras, configured with one on each connector, for use with the single-alvium flex cables
+
+> Note 1. Not all cameras need to be present in order for a configuration to work at runtime. Unless there are other
+restrictions or limitations, the '`Antmicro All`' configuration provided here should be suitable for *most*
+applications with CSI cameras supporting 2-lanes, regardless of the number or position of cameras/ports.
+
+If you wish to use a customised configuration: Note down the information in the table above for your chosen
+arrangement of cameras and ports, then see the section [Create a custom configuration](#2-optional-create-a-custom-configuration)
+
+## Building the driver
+
+### 1. Clone the allied vision and antmicro repositories and apply the patch file
+
+```Bash
+git clone https://github.com/alliedvision/linux_nvidia_jetson --branch l4t-35.1.0-5.0.2-beta1
+git clone https://github.com/antmicro/jetson-nano-baseboard.git
+cd linux_nvidia_jetson
+patch -p1 < ../jetson-nano-baseboard/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
+```
+
+### 2. [Optional] Create a custom configuration
+
+If your application needs are not supported by one of the above configurations, you can modify the device tree files
+yourself before compiling the patch. Each configuration is located in the alliedvision repository under
+`linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/` and has 3 unique files:
+
+1. 2 top-level dts definitions, one for each version of xavier NX module `tegra194-p3668-0000-p3509-0000-antmicro-XXXX.dts` (dev) and `tegra194-p3668-0001-p3509-0000-XXXX.dts` (prod).
+2. A single dtsi file specifying the camera layout, located at `common/tegra194-camera-jakku-avt-csi2-antmicro-XXXX.dtsi`
+
+> (where XXXX is the name for the specific configuration)
+
+To add a new configuration to the Allied Vision driver:
+
+1. Under `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/common`, create a new dtsi file with the name `tegra194-camera-jakku-avt-csi2-antmicro-<your-config-name>.dtsi`. Use the "antmicro-all" configuration as a
+starting point and then refer to the [nvidia camera development guide](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/SD/CameraDevelopment/SensorSoftwareDriverProgramming.html) for more information on how to adjust the configuration.
+2. Under `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/`, Create a top-level .dts entry for each
+xavier module type `tegra194-p3668-0000-p3509-0000-antmicro-<your-config-name>.dts` and
+`tegra194-p3668-0001-p3509-0000-antmicro-<your-config-name>.dts`. Again, use the "antmicro-all" files as a
+starting point.
+3. Edit `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile` and add the lines for your
+configuration alongside the existing antmicro definitions.
+4. Edit `linux_nvidia_jetson/avt_build/jetson_build/files/bootloader/config` and under the section for "nx_devkit", add
+your configuration to the list (following the format for the existing configurations).
+
+> You can also refer to the existing patch file for a reference for which specific modifications to make.
+
+### 3. Build
+
+Run the build script from inside the alliedvision driver repository:
+
+```Bash
+cd linux_nvidia_jetson/avt_build
+sudo ./build -b xavier
+```
+
+The build script will package the driver up into a compressed tarball containing the debian packages and an install script. It can be found under `linux_nvidia_jetson/avt_build/work/xavier/Linux_for_Tegra/kernel/avt/` with the prefix `AlliedVision_NVidia_L4T_35.1.0_5.0.2`
+
+## Deploying the driver
+
+1. Boot the NX running the stock JP5.0.2 on the baseboard
+2. Copy the tarball generated above onto the NX and extract
+3. run the provided install script.
+4. During this process you will be given the option to choose an installation configuration (if not, finish
+the install, reboot, then run ```sudo dpkg-reconfigure avt-nvidia-l4t-bootloader```). Select the 'Antmicro XXXX' option
+for your use case from the list and the installer will update the boot configuration to use the custom device tree.
+5. Reboot to load the new device tree.

--- a/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
+++ b/linux-patches/alliedvision-driver-patching-guide-xavier-nx-jp5.0.2.md
@@ -42,13 +42,11 @@ to index 5 for this camera.
 
 The following configurations are provided by this patch:
 
-- **Antmicro All**: The default, all 4 ports enabled at 2-lanes, use with any configuration of camera's and cables.
-- **Antmicro Dual J6**: 2x 2-lane cameras configured on J6, for use with the dual-alvium flex cable
-- **Antmicro Dual J7**: 2x 4-lane cameras configured on J7, for use with the dual-alvium flex cable
-- **Antmicro Dual Split**: 2x 4-lane cameras, configured with one on each connector, for use with the single-alvium flex cables
+- **Antmicro**: The default, all 4 ports enabled at 2-lanes, use with any configuration of camera's and cables.
+- **Antmicro 4-Lane**: All 3 ports supporting 4-lanes enabled at full-width, J6 Left camera disabled (see note 2 above)
 
 > Note 1. Not all cameras need to be present in order for a configuration to work at runtime. Unless there are other
-restrictions or limitations, the '`Antmicro All`' configuration provided here should be suitable for *most*
+restrictions or limitations, the '`Antmicro`' configuration provided here should be suitable for *most*
 applications with CSI cameras supporting 2-lanes, regardless of the number or position of cameras/ports.
 
 If you wish to use a customised configuration: Note down the information in the table above for your chosen
@@ -78,11 +76,11 @@ yourself before compiling the patch. Each configuration is located in the allied
 
 To add a new configuration to the Allied Vision driver:
 
-1. Under `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/common`, create a new dtsi file with the name `tegra194-camera-jakku-avt-csi2-antmicro-<your-config-name>.dtsi`. Use the "antmicro-all" configuration as a
+1. Under `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/common`, create a new dtsi file with the name `tegra194-camera-jakku-avt-csi2-antmicro-<your-config-name>.dtsi`. Use the antmicro base configuration as a
 starting point and then refer to the [nvidia camera development guide](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/SD/CameraDevelopment/SensorSoftwareDriverProgramming.html) for more information on how to adjust the configuration.
 2. Under `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/`, Create a top-level .dts entry for each
 xavier module type `tegra194-p3668-0000-p3509-0000-antmicro-<your-config-name>.dts` and
-`tegra194-p3668-0001-p3509-0000-antmicro-<your-config-name>.dts`. Again, use the "antmicro-all" files as a
+`tegra194-p3668-0001-p3509-0000-antmicro-<your-config-name>.dts`. Again, use the base antmicro files as a
 starting point.
 3. Edit `linux_nvidia_jetson/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile` and add the lines for your
 configuration alongside the existing antmicro definitions.

--- a/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
+++ b/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
@@ -1,91 +1,67 @@
-From d9dc4f679679ed48d73ba29eb9ccb93007e0f567 Mon Sep 17 00:00:00 2001
-From: Tom Molnar <tom.molnar@csiro.au>
-Date: Mon, 13 Feb 2023 10:11:41 +1000
-Subject: [PATCH] jakku: add support for Antmicro JNB rev.1.5.1 (multiple configurations)
+From 68df43eccda107ff3ae53b88aa54ad8c2aa2e77f Mon Sep 17 00:00:00 2001
+From: T Molnar <Tom.Molnar@csiro.au>
+Date: Fri, 17 Feb 2023 15:03:03 +1000
+Subject: [PATCH] jakku: add support for Antmicro JNB rev.1.5.1 (Xavier NX)
 
 ---
- .../jetson_build/files/bootloader/config      |  16 +
- .../platform/t19x/jakku/kernel-dts/Makefile   |   8 +
- ...94-camera-jakku-avt-csi2-antmicro-all.dtsi | 541 ++++++++++++++++++
- ...amera-jakku-avt-csi2-antmicro-dual-j6.dtsi | 315 ++++++++++
- ...amera-jakku-avt-csi2-antmicro-dual-j7.dtsi | 314 ++++++++++
- ...ra-jakku-avt-csi2-antmicro-dual-split.dtsi | 315 ++++++++++
- ...194-p3668-0000-p3509-0000-antmicro-all.dts |  34 ++
- ...p3668-0000-p3509-0000-antmicro-dual-j6.dts |  34 ++
- ...p3668-0000-p3509-0000-antmicro-dual-j7.dts |  34 ++
- ...68-0000-p3509-0000-antmicro-dual-split.dts |  34 ++
- ...194-p3668-0001-p3509-0000-antmicro-all.dts |  31 +
- ...p3668-0001-p3509-0000-antmicro-dual-j6.dts |  31 +
- ...p3668-0001-p3509-0000-antmicro-dual-j7.dts |  31 +
- ...68-0001-p3509-0000-antmicro-dual-split.dts |  31 +
- 14 files changed, 1769 insertions(+)
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts
- create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts
+ .../jetson_build/files/bootloader/config      |   8 +
+ .../platform/t19x/jakku/kernel-dts/Makefile   |   4 +
+ ...-camera-jakku-avt-csi2-antmicro-4lane.dtsi | 432 ++++++++++++++
+ ...gra194-camera-jakku-avt-csi2-antmicro.dtsi | 543 ++++++++++++++++++
+ ...4-p3668-0000-p3509-0000-antmicro-4lane.dts |  34 ++
+ ...egra194-p3668-0000-p3509-0000-antmicro.dts |  34 ++
+ ...4-p3668-0001-p3509-0000-antmicro-4lane.dts |  32 ++
+ ...egra194-p3668-0001-p3509-0000-antmicro.dts |  31 +
+ 8 files changed, 1118 insertions(+)
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-4lane.dtsi
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro.dtsi
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-4lane.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-4lane.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro.dts
 
 diff --git a/avt_build/jetson_build/files/bootloader/config b/avt_build/jetson_build/files/bootloader/config
-index d936d580b..3b960926e 100644
+index d936d580b..c761cda31 100644
 --- a/avt_build/jetson_build/files/bootloader/config
 +++ b/avt_build/jetson_build/files/bootloader/config
-@@ -82,6 +82,22 @@ nx_devkit = BoardDefinition('Jetson Xavier NX devkit', '0x19', '3668', [
+@@ -82,6 +82,14 @@ nx_devkit = BoardDefinition('Jetson Xavier NX devkit', '0x19', '3668', [
      #NX 16GB
      Configuration('DevKit', 'tegra194-p3668-0001-p3509-0000-avt.dtb', '0003'),
  
-+    Configuration('Antmicro All', 'tegra194-p3668-0000-p3509-0000-antmicro-all.dtb', '0000'),
-+    Configuration('Antmicro All', 'tegra194-p3668-0001-p3509-0000-antmicro-all.dtb', '0001'),
-+    Configuration('Antmicro All', 'tegra194-p3668-0001-p3509-0000-antmicro-all.dtb', '0003'),
++    Configuration('Antmicro JNB', 'tegra194-p3668-0000-p3509-0000-antmicro.dtb', '0000'),
++    Configuration('Antmicro JNB', 'tegra194-p3668-0001-p3509-0000-antmicro.dtb', '0001'),
++    Configuration('Antmicro JNB', 'tegra194-p3668-0001-p3509-0000-antmicro.dtb', '0003'),
 +
-+    Configuration('Antmicro Dual-J6', 'tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dtb', '0000'),
-+    Configuration('Antmicro Dual-J6', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dtb', '0001'),
-+    Configuration('Antmicro Dual-J6', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dtb', '0003'),
-+
-+    Configuration('Antmicro Dual-J7', 'tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dtb', '0000'),
-+    Configuration('Antmicro Dual-J7', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dtb', '0001'),
-+    Configuration('Antmicro Dual-J7', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dtb', '0003'),
-+
-+    Configuration('Antmicro Dual-Split', 'tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dtb', '0000'),
-+    Configuration('Antmicro Dual-Split', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dtb', '0001'),
-+    Configuration('Antmicro Dual-Split', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dtb', '0003'),
++    Configuration('Antmicro JNB 4-lane', 'tegra194-p3668-0000-p3509-0000-antmicro-4lane.dtb', '0000'),
++    Configuration('Antmicro JNB 4-lane', 'tegra194-p3668-0001-p3509-0000-antmicro-4lane.dtb', '0001'),
++    Configuration('Antmicro JNB 4-lane', 'tegra194-p3668-0001-p3509-0000-antmicro-4lane.dtb', '0003'),
 +
      #Configuration('Auvidea JNX30 (beta)', 'tegra194-p3668-all-p3509-0000-auvidea-jnx30.dtb', '0000', beta=True),
      #Configuration('Auvidea JNX30 (beta)', 'tegra194-p3668-all-p3509-0000-auvidea-jnx30.dtb', '0001', beta=True),
      #NX 16GB
 diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile b/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
-index 8e6787ccf..d1429fdbf 100644
+index 8e6787ccf..0a6e7e636 100644
 --- a/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
 +++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
-@@ -11,8 +11,16 @@ endif
+@@ -11,8 +11,12 @@ endif
  
  dtb-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000.dtb
  dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-all.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-4lane.dtb
  dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-avt.dtb
  dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-all.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dtb
-+dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-4lane.dtb
  dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-avt.dtb
  dtb-$(CONFIG_ARCH_TEGRA_19x_SOC) += tegra194-p3668-all-p3509-0000-kexec.dtb
  dtbo-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000-hdr40.dtbo
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-4lane.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-4lane.dtsi
 new file mode 100644
-index 000000000..15a67243e
+index 000000000..36fa1b0fe
 --- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi
-@@ -0,0 +1,541 @@
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-4lane.dtsi
+@@ -0,0 +1,432 @@
 +/*
 + * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
 + *
@@ -107,8 +83,8 @@ index 000000000..15a67243e
 +#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
 +
 +/ {
-+	tegra-capture-vi  {
-+			num-channels = <4>;
++	tc_vi: tegra-capture-vi  {
++			num-channels = <3>;
 +			ports {
 +				#address-cells = <1>;
 +				#size-cells = <0>;
@@ -116,8 +92,8 @@ index 000000000..15a67243e
 +				vi_port0: port@0 {
 +					reg = <0>;
 +					avt_csi2_vi_in0: endpoint {
-+						port-index = <5>;
-+						bus-width = <2>;
++						port-index = <2>;
++						bus-width = <4>;
 +						remote-endpoint = <&avt_csi2_csi_out0>;
 +					};
 +				};
@@ -125,8 +101,8 @@ index 000000000..15a67243e
 +				vi_port1: port@1 {
 +					reg = <1>;
 +					avt_csi2_vi_in1: endpoint {
-+						port-index = <2>;
-+						bus-width = <2>;
++						port-index = <0>;
++						bus-width = <4>;
 +						remote-endpoint = <&avt_csi2_csi_out1>;
 +					};
 +				};
@@ -134,28 +110,19 @@ index 000000000..15a67243e
 +				vi_port2: port@2 {
 +					reg = <2>;
 +					avt_csi2_vi_in2: endpoint {
-+						port-index = <0>;
-+						bus-width = <2>;
-+						remote-endpoint = <&avt_csi2_csi_out2>;
-+					};
-+				};
-+
-+				vi_port3: port@3 {
-+					reg = <3>;
-+					avt_csi2_vi_in3: endpoint {
 +						port-index = <4>;
-+						bus-width = <2>;
-+						remote-endpoint = <&avt_csi2_csi_out3>;
++						bus-width = <4>;
++						remote-endpoint = <&avt_csi2_csi_out2>;
 +					};
 +				};
 +			};
 +		};
 +
 +	host1x@13e00000 {
-+		nvcsi@15a00000 {
-+			num-channels = <4>;
++		nv_csi: nvcsi@15a00000 {
++			num-channels = <3>;
 +			
-+      #address-cells = <1>;
++			#address-cells = <1>;
 +			#size-cells = <0>;
 +
 +			csi_chan0: channel@0 {
@@ -166,8 +133,8 @@ index 000000000..15a67243e
 +					csi_chan0_port0: port@0 {
 +						reg = <0>;
 +						avt_csi2_csi_in0: endpoint@0 {
-+							port-index = <6>;
-+							bus-width = <2>;
++							port-index = <2>;
++							bus-width = <4>;
 +							remote-endpoint = <&avt_csi2_out0>;
 +						};
 +					};
@@ -188,8 +155,8 @@ index 000000000..15a67243e
 +					csi_chan1_port0: port@0 {
 +						reg = <0>;
 +						avt_csi2_csi_in1: endpoint@0 {
-+							port-index = <2>;
-+							bus-width = <2>;
++							port-index = <0>;
++							bus-width = <4>;
 +							remote-endpoint = <&avt_csi2_out1>;
 +						};
 +					};
@@ -210,8 +177,8 @@ index 000000000..15a67243e
 +					csi_chan2_port0: port@0 {
 +						reg = <0>;
 +						avt_csi2_csi_in2: endpoint@0 {
-+							port-index = <0>;
-+							bus-width = <2>;
++							port-index = <4>;
++							bus-width = <4>;
 +							remote-endpoint = <&avt_csi2_out2>;
 +						};
 +					};
@@ -219,28 +186,6 @@ index 000000000..15a67243e
 +						reg = <1>;
 +						avt_csi2_csi_out2: endpoint@1 {
 +							remote-endpoint = <&avt_csi2_vi_in2>;
-+						};
-+					};
-+				};
-+			};
-+
-+			csi_chan3: channel@3 {
-+				reg = <3>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan3_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in3: endpoint@0 {
-+							port-index = <4>;
-+							bus-width = <2>;
-+							remote-endpoint = <&avt_csi2_out3>;
-+						};
-+					};
-+					csi_chan3_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out3: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in3>;
 +						};
 +					};
 +				};
@@ -259,24 +204,24 @@ index 000000000..15a67243e
 +			vcc-supply = <&battery_reg>;
 +			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
 +
-+			i2c@0 {
-+				reg = <0>;
++			i2c@1 {
++				reg = <1>;
 +				i2c-mux,deselect-on-exit;
 +				#address-cells = <1>;
 +				#size-cells = <0>;
-+
 +				avt_csi2@3c {
 +					compatible = "alliedvision,avt_csi2";
 +					/* I2C device address */
 +					reg = <0x3c>;
++
 +					status = "okay";
 +
 +					/* V4L2 device node location */
 +					devnode = "video0";
 +
 +					mode0 {
-+						num_lanes = "2";
-+						tegra_sinterface = "serial_g";
++						num_lanes = "4";
++						tegra_sinterface = "serial_e";
 +						discontinuous_clk = "no";
 +						cil_settletime = "0";
 +						embedded_metadata_height = "0";
@@ -286,10 +231,10 @@ index 000000000..15a67243e
 +						phy_mode = "DPHY";
 +						dpcm_enable = "false";
 +
-+						csi_pixel_bit_depth = "4";
 +						active_w = "5488";
 +						active_h = "4112";
 +						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
 +						readout_orientation = "0";
 +						line_length = "5488";
 +						inherent_gain = "1";
@@ -319,8 +264,8 @@ index 000000000..15a67243e
 +							reg = <0>;
 +							avt_csi2_out0: endpoint {
 +								status = "okay";
-+								port-index = <5>;
-+								bus-width = <2>;
++								port-index = <2>;
++								bus-width = <4>;
 +								remote-endpoint = <&avt_csi2_csi_in0>;
 +							};
 +						};
@@ -328,12 +273,11 @@ index 000000000..15a67243e
 +				};
 +			};
 +
-+			i2c@1 {
-+				reg = <1>;
++			i2c@2 {
++				reg = <2>;
 +				i2c-mux,deselect-on-exit;
 +				#address-cells = <1>;
 +				#size-cells = <0>;
-+
 +				avt_csi2@3c {
 +					compatible = "alliedvision,avt_csi2";
 +					/* I2C device address */
@@ -345,8 +289,8 @@ index 000000000..15a67243e
 +					devnode = "video1";
 +
 +					mode0 {
-+						num_lanes = "2";
-+						tegra_sinterface = "serial_e";
++						num_lanes = "4";
++						tegra_sinterface = "serial_a";
 +						discontinuous_clk = "no";
 +						cil_settletime = "0";
 +						embedded_metadata_height = "0";
@@ -356,10 +300,10 @@ index 000000000..15a67243e
 +						phy_mode = "DPHY";
 +						dpcm_enable = "false";
 +
-+						csi_pixel_bit_depth = "4";
 +						active_w = "5488";
 +						active_h = "4112";
 +						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
 +						readout_orientation = "0";
 +						line_length = "5488";
 +						inherent_gain = "1";
@@ -389,8 +333,8 @@ index 000000000..15a67243e
 +							reg = <0>;
 +							avt_csi2_out1: endpoint {
 +								status = "okay";
-+								port-index = <2>;
-+								bus-width = <2>;
++								port-index = <0>;
++								bus-width = <4>;
 +								remote-endpoint = <&avt_csi2_csi_in1>;
 +							};
 +						};
@@ -398,8 +342,8 @@ index 000000000..15a67243e
 +				};
 +			};
 +
-+			i2c@2 {
-+				reg = <2>;
++			i2c@3 {
++				reg = <3>;
 +				i2c-mux,deselect-on-exit;
 +				#address-cells = <1>;
 +				#size-cells = <0>;
@@ -414,8 +358,8 @@ index 000000000..15a67243e
 +					devnode = "video2";
 +
 +					mode0 {
-+						num_lanes = "2";
-+						tegra_sinterface = "serial_a";
++						num_lanes = "4";
++						tegra_sinterface = "serial_c";
 +						discontinuous_clk = "no";
 +						cil_settletime = "0";
 +						embedded_metadata_height = "0";
@@ -457,16 +401,417 @@ index 000000000..15a67243e
 +						port@0 {
 +							reg = <0>;
 +							avt_csi2_out2: endpoint {
-+								port-index = <0>;
-+								bus-width = <2>;
++								status = "okay";
++								port-index = <4>;
++								bus-width = <4>;
 +								remote-endpoint = <&avt_csi2_csi_in2>;
 +							};
 +						};
 +					};
 +				};
 +			};
++		};
++	};
 +
-+			i2c@3 {
++	tcp: tegra-camera-platform {
++		compatible = "nvidia, tegra-camera-platform";
++		/**
++		* Physical settings to calculate max ISO BW
++		*
++		* num_csi_lanes = <>;
++		* Total number of CSI lanes when all cameras are active
++		*
++		* max_lane_speed = <>;
++		* Max lane speed in Kbit/s
++		*
++		* min_bits_per_pixel = <>;
++		* Min bits per pixel
++		*
++		* vi_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the VI ISO case
++		*
++		* vi_bw_margin_pct = <>;
++		* Vi bandwidth margin in percentage
++		*
++		* max_pixel_rate = <>;
++		* Max pixel rate in Kpixel/s for the ISP ISO case
++		*
++		* isp_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the ISP ISO case
++		*
++		* isp_bw_margin_pct = <>;
++		* Isp bandwidth margin in percentage
++		*/
++		num_csi_lanes = <12>;
++		max_lane_speed = <1500000>;
++		min_bits_per_pixel = <8>;
++		vi_peak_byte_per_pixel = <2>;
++		vi_bw_margin_pct = <25>;
++		max_pixel_rate = <160000>;
++		isp_peak_byte_per_pixel = <5>;
++		isp_bw_margin_pct = <25>;
++
++		/**
++		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
++		 * The first part is the camera_board_id for the module; if the module is in a FFD
++		 * platform, then use the platform name for this part.
++		 * The second part contains the position of the module, ex. "rear" or "front".
++		 * The third part contains the last 6 characters of a part number which is found
++		 * in the module's specsheet from the vendor.
++		 */
++		modules {
++			cam_module0: module0 {
++				badge = "avt_csi2";
++				position = "topright";
++				orientation = "1";
++				cam_module0_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 31-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
++				};
++			};
++			cam_module1: module1 {
++				badge = "avt_csi2";
++				position = "bottomright";
++				orientation = "1";
++				cam_module1_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 32-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
++				};
++			};
++			cam_module2: module2 {
++				badge = "avt_csi2";
++				position = "bottomleft";
++				orientation = "1";
++				cam_module2_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 33-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@3/avt_csi2@3c";
++				};
++			};
++		};
++	};
++};
++
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro.dtsi
+new file mode 100644
+index 000000000..084acb9be
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro.dtsi
+@@ -0,0 +1,543 @@
++/*
++ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++#include <dt-bindings/media/camera.h>
++
++#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
++
++/ {
++	tc_vi: tegra-capture-vi  {
++			num-channels = <4>;
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				vi_port0: port@0 {
++					reg = <0>;
++					avt_csi2_vi_in0: endpoint {
++						port-index = <2>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out0>;
++					};
++				};
++
++				vi_port1: port@1 {
++					reg = <1>;
++					avt_csi2_vi_in1: endpoint {
++						port-index = <0>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out1>;
++					};
++				};
++
++				vi_port2: port@2 {
++					reg = <2>;
++					avt_csi2_vi_in2: endpoint {
++						port-index = <4>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out2>;
++					};
++				};
++
++				vi_port3: port@3 {
++					reg = <3>;
++					avt_csi2_vi_in3: endpoint {
++						port-index = <5>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out3>;
++					};
++				};
++
++			};
++		};
++
++	host1x@13e00000 {
++		nv_csi: nvcsi@15a00000 {
++			num-channels = <4>;
++			
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csi_chan0: channel@0 {
++				reg = <0>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan0_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in0: endpoint@0 {
++							port-index = <2>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out0>;
++						};
++					};
++					csi_chan0_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out0: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in0>;
++						};
++					};
++				};
++			};
++
++			csi_chan1: channel@1 {
++				reg = <1>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan1_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in1: endpoint@0 {
++							port-index = <0>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out1>;
++						};
++					};
++					csi_chan1_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out1: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in1>;
++						};
++					};
++				};
++			};
++
++			csi_chan2: channel@2 {
++				reg = <2>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan2_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in2: endpoint@0 {
++							port-index = <4>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out2>;
++						};
++					};
++					csi_chan2_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out2: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in2>;
++						};
++					};
++				};
++			};
++
++			csi_chan3: channel@3 {
++				reg = <3>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan3_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in3: endpoint@0 {
++							port-index = <6>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out3>;
++						};
++					};
++					csi_chan3_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out3: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in3>;
++						};
++					};
++				};
++			};
++		};
++	};
++
++	i2c@3180000 {
++		avt_pca9547: avt_pca9547@70 {
++			compatible = "nxp,pca9547";
++			status = "okay";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			vcc-supply = <&battery_reg>;
++			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++
++			i2c1: i2c@1 {
++				reg = <1>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video0";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_e";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out0: endpoint {
++								status = "okay";
++								port-index = <2>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in0>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c2: i2c@2 {
++				reg = <2>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video1";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_a";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out1: endpoint {
++								status = "okay";
++								port-index = <0>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in1>;
++							};
++						};
++					};
++				};
++			};
++
++			i23: i2c@3 {
 +				reg = <3>;
 +				i2c-mux,deselect-on-exit;
 +				#address-cells = <1>;
@@ -479,7 +824,7 @@ index 000000000..15a67243e
 +					status = "okay";
 +
 +					/* V4L2 device node location */
-+					devnode = "video3";
++					devnode = "video2";
 +
 +					mode0 {
 +						num_lanes = "2";
@@ -524,220 +869,18 @@ index 000000000..15a67243e
 +						#size-cells = <0>;
 +						port@0 {
 +							reg = <0>;
-+							avt_csi2_out3: endpoint {
++							avt_csi2_out2: endpoint {
++								status = "okay";
 +								port-index = <4>;
 +								bus-width = <2>;
-+								remote-endpoint = <&avt_csi2_csi_in3>;
++								remote-endpoint = <&avt_csi2_csi_in2>;
 +							};
 +						};
 +					};
 +				};
 +			};
-+		};
-+	};
 +
-+	tcp: tegra-camera-platform {
-+		compatible = "nvidia, tegra-camera-platform";
-+		/**
-+		* Physical settings to calculate max ISO BW
-+		*
-+		* num_csi_lanes = <>;
-+		* Total number of CSI lanes when all cameras are active
-+		*
-+		* max_lane_speed = <>;
-+		* Max lane speed in Kbit/s
-+		*
-+		* min_bits_per_pixel = <>;
-+		* Min bits per pixel
-+		*
-+		* vi_peak_byte_per_pixel = <>;
-+		* Max byte per pixel for the VI ISO case
-+		*
-+		* vi_bw_margin_pct = <>;
-+		* Vi bandwidth margin in percentage
-+		*
-+		* max_pixel_rate = <>;
-+		* Max pixel rate in Kpixel/s for the ISP ISO case
-+		*
-+		* isp_peak_byte_per_pixel = <>;
-+		* Max byte per pixel for the ISP ISO case
-+		*
-+		* isp_bw_margin_pct = <>;
-+		* Isp bandwidth margin in percentage
-+		*/
-+		num_csi_lanes = <8>;
-+		max_lane_speed = <1500000>;
-+		min_bits_per_pixel = <8>;
-+		vi_peak_byte_per_pixel = <2>;
-+		vi_bw_margin_pct = <25>;
-+		max_pixel_rate = <160000>;
-+		isp_peak_byte_per_pixel = <5>;
-+		isp_bw_margin_pct = <25>;
-+
-+		/**
-+		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
-+		 * The first part is the camera_board_id for the module; if the module is in a FFD
-+		 * platform, then use the platform name for this part.
-+		 * The second part contains the position of the module, ex. "rear" or "front".
-+		 * The third part contains the last 6 characters of a part number which is found
-+		 * in the module's specsheet from the vendor.
-+		 */
-+		modules {
-+			cam_module0: module0 {
-+				badge = "avt_csi2";
-+				position = "topleft";
-+				orientation = "1";
-+				cam_module0_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 30-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@0/avt_csi2@3c";
-+				};
-+			};
-+			cam_module1: module1 {
-+				badge = "avt_csi2";
-+				position = "topright";
-+				orientation = "1";
-+				cam_module1_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 31-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
-+				};
-+			};
-+			cam_module2: module2 {
-+				badge = "avt_csi2";
-+				position = "bottomright";
-+				orientation = "1";
-+				cam_module2_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 32-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
-+				};
-+			};
-+			cam_module3: module3 {
-+				badge = "avt_csi2";
-+				position = "bottomleft";
-+				orientation = "1";
-+				cam_module3_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 33-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@3/avt_csi2@3c";
-+				};
-+			};
-+		};
-+	};
-+};
-+
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi
-new file mode 100644
-index 000000000..38c569d35
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi
-@@ -0,0 +1,315 @@
-+/*
-+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-+ */
-+#include <dt-bindings/media/camera.h>
-+
-+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
-+
-+/ {
-+	tegra-capture-vi  {
-+			num-channels = <2>;
-+			ports {
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+				vi_port0: port@0 {
-+					reg = <0>;
-+					avt_csi2_vi_in0: endpoint {
-+						port-index = <5>;
-+						bus-width = <2>;
-+						remote-endpoint = <&avt_csi2_csi_out0>;
-+					};
-+				};
-+				vi_port1: port@1 {
-+					reg = <1>;
-+					avt_csi2_vi_in1: endpoint {
-+						port-index = <2>;
-+						bus-width = <2>;
-+						remote-endpoint = <&avt_csi2_csi_out1>;
-+					};
-+				};
-+			};
-+		};
-+	host1x@13e00000 {
-+		nvcsi@15a00000 {
-+			num-channels = <2>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			csi_chan0: channel@0 {
-+				reg = <0>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan0_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in0: endpoint@0 {
-+							port-index = <6>;
-+							bus-width = <2>;
-+							remote-endpoint = <&avt_csi2_out0>;
-+						};
-+					};
-+					csi_chan0_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out0: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in0>;
-+						};
-+					};
-+				};
-+			};
-+			csi_chan1: channel@1 {
-+				reg = <1>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan1_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in1: endpoint@0 {
-+							port-index = <2>;
-+							bus-width = <2>;
-+							remote-endpoint = <&avt_csi2_out1>;
-+						};
-+					};
-+					csi_chan1_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out1: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in1>;
-+						};
-+					};
-+				};
-+			};
-+		};
-+	};
-+
-+	i2c@3180000 {
-+		avt_pca9547: avt_pca9547@70 {
-+			compatible = "nxp,pca9547";
-+			status = "okay";
-+			reg = <0x70>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			vcc-supply = <&battery_reg>;
-+			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
-+
-+				i2c@0 {
++			i2c0: i2c@0 {
 +				reg = <0>;
 +				i2c-mux,deselect-on-exit;
 +				#address-cells = <1>;
@@ -750,7 +893,7 @@ index 000000000..38c569d35
 +					status = "okay";
 +
 +					/* V4L2 device node location */
-+					devnode = "video0";
++					devnode = "video3";
 +
 +					mode0 {
 +						num_lanes = "2";
@@ -795,406 +938,17 @@ index 000000000..38c569d35
 +						#size-cells = <0>;
 +						port@0 {
 +							reg = <0>;
-+							avt_csi2_out0: endpoint {
++							avt_csi2_out3: endpoint {
++								status = "okay";
 +								port-index = <5>;
 +								bus-width = <2>;
-+								remote-endpoint = <&avt_csi2_csi_in0>;
++								remote-endpoint = <&avt_csi2_csi_in3>;
 +							};
 +						};
 +					};
 +				};
 +			};
 +
-+			i2c@1 {
-+				reg = <1>;
-+				i2c-mux,deselect-on-exit;
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+
-+				avt_csi2@3c {
-+					compatible = "alliedvision,avt_csi2";
-+					/* I2C device address */
-+					reg = <0x3c>;
-+
-+					status = "okay";
-+
-+					/* V4L2 device node location */
-+					devnode = "video1";
-+
-+					mode0 {
-+						num_lanes = "2";
-+						tegra_sinterface = "serial_e";
-+						discontinuous_clk = "no";
-+						cil_settletime = "0";
-+						embedded_metadata_height = "0";
-+
-+						/* not verified: */
-+						mclk_khz = "24000";
-+						phy_mode = "DPHY";
-+						dpcm_enable = "false";
-+
-+						csi_pixel_bit_depth = "4";
-+						active_w = "5488";
-+						active_h = "4112";
-+						pixel_t = "bayer_bggr";
-+						readout_orientation = "0";
-+						line_length = "5488";
-+						inherent_gain = "1";
-+						mclk_multiplier = "31.25";
-+						pix_clk_hz = "750000000";
-+
-+						gain_factor = "16";
-+						framerate_factor = "1000000";
-+						exposure_factor = "1000000";
-+						min_gain_val = "16"; /* 1.0 */
-+						max_gain_val = "256"; /* 16.0 */
-+						step_gain_val = "1"; /* 0.125 */
-+						min_hdr_ratio = "1";
-+						max_hdr_ratio = "64";
-+						min_framerate = "1500000"; /* 1.5 */
-+						max_framerate = "30000000"; /* 30 */
-+						step_framerate = "1";
-+						min_exp_time = "34"; /* us */
-+						max_exp_time = "550385"; /* us */
-+						step_exp_time = "1";
-+					};
-+
-+					ports {
-+						#address-cells = <1>;
-+						#size-cells = <0>;
-+						port@0 {
-+							reg = <0>;
-+							avt_csi2_out1: endpoint {
-+								status = "okay";
-+								port-index = <2>;
-+								bus-width = <2>;
-+								remote-endpoint = <&avt_csi2_csi_in1>;
-+							};
-+						};
-+					};
-+				};
-+			};
-+		};
-+	};
-+
-+	tcp: tegra-camera-platform {
-+		compatible = "nvidia, tegra-camera-platform";
-+		/**
-+		* Physical settings to calculate max ISO BW
-+		*
-+		* num_csi_lanes = <>;
-+		* Total number of CSI lanes when all cameras are active
-+		*
-+		* max_lane_speed = <>;
-+		* Max lane speed in Kbit/s
-+		*
-+		* min_bits_per_pixel = <>;
-+		* Min bits per pixel
-+		*
-+		* vi_peak_byte_per_pixel = <>;
-+		* Max byte per pixel for the VI ISO case
-+		*
-+		* vi_bw_margin_pct = <>;
-+		* Vi bandwidth margin in percentage
-+		*
-+		* max_pixel_rate = <>;
-+		* Max pixel rate in Kpixel/s for the ISP ISO case
-+		*
-+		* isp_peak_byte_per_pixel = <>;
-+		* Max byte per pixel for the ISP ISO case
-+		*
-+		* isp_bw_margin_pct = <>;
-+		* Isp bandwidth margin in percentage
-+		*/
-+		num_csi_lanes = <4>;
-+		max_lane_speed = <1500000>;
-+		min_bits_per_pixel = <8>;
-+		vi_peak_byte_per_pixel = <2>;
-+		vi_bw_margin_pct = <25>;
-+		max_pixel_rate = <160000>;
-+		isp_peak_byte_per_pixel = <5>;
-+		isp_bw_margin_pct = <25>;
-+
-+		/**
-+		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
-+		 * The first part is the camera_board_id for the module; if the module is in a FFD
-+		 * platform, then use the platform name for this part.
-+		 * The second part contains the position of the module, ex. "rear" or "front".
-+		 * The third part contains the last 6 characters of a part number which is found
-+		 * in the module's specsheet from the vendor.
-+		 */
-+		modules {
-+			cam_module0: module0 {
-+				badge = "avt_csi2";
-+				position = "front";
-+				orientation = "1";
-+				cam_module0_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 30-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@0/avt_csi2@3c";
-+				};
-+			};
-+			cam_module1: module1 {
-+				badge = "avt_csi2";
-+				position = "rear";
-+				orientation = "1";
-+				cam_module1_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 31-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
-+				};
-+			};
-+		};
-+	};
-+};
-+
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi
-new file mode 100644
-index 000000000..e4723713b
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi
-@@ -0,0 +1,314 @@
-+/*
-+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-+ */
-+#include <dt-bindings/media/camera.h>
-+
-+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
-+
-+/ {
-+	tegra-capture-vi  {
-+			num-channels = <2>;
-+			ports {
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+				vi_port0: port@0 {
-+					reg = <0>;
-+					avt_csi2_vi_in0: endpoint {
-+						port-index = <0>;
-+						bus-width = <4>;
-+						remote-endpoint = <&avt_csi2_csi_out0>;
-+					};
-+				};
-+				vi_port1: port@1 {
-+					reg = <1>;
-+					avt_csi2_vi_in1: endpoint {
-+						port-index = <4>;
-+						bus-width = <4>;
-+						remote-endpoint = <&avt_csi2_csi_out1>;
-+					};
-+				};
-+			};
-+		};
-+	host1x@13e00000 {
-+		nvcsi@15a00000 {
-+			num-channels = <2>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			csi_chan0: channel@0 {
-+				reg = <0>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan0_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in0: endpoint@0 {
-+							port-index = <0>;
-+							bus-width = <4>;
-+							remote-endpoint = <&avt_csi2_out0>;
-+						};
-+					};
-+					csi_chan0_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out0: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in0>;
-+						};
-+					};
-+				};
-+			};
-+			csi_chan1: channel@1 {
-+				reg = <1>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan1_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in1: endpoint@0 {
-+							port-index = <4>;
-+							bus-width = <4>;
-+							remote-endpoint = <&avt_csi2_out1>;
-+						};
-+					};
-+					csi_chan1_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out1: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in1>;
-+						};
-+					};
-+				};
-+			};
-+		};
-+	};
-+
-+	i2c@3180000 {
-+		avt_pca9547: avt_pca9547@70 {
-+			compatible = "nxp,pca9547";
-+			status = "okay";
-+			reg = <0x70>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			vcc-supply = <&battery_reg>;
-+			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
-+
-+				i2c@2 {
-+				reg = <2>;
-+				i2c-mux,deselect-on-exit;
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+				avt_csi2@3c {
-+					compatible = "alliedvision,avt_csi2";
-+					/* I2C device address */
-+					reg = <0x3c>;
-+
-+					status = "okay";
-+
-+					/* V4L2 device node location */
-+					devnode = "video0";
-+
-+					mode0 {
-+						num_lanes = "4";
-+						tegra_sinterface = "serial_a";
-+						discontinuous_clk = "no";
-+						cil_settletime = "0";
-+						embedded_metadata_height = "0";
-+
-+						/* not verified: */
-+						mclk_khz = "24000";
-+						phy_mode = "DPHY";
-+						dpcm_enable = "false";
-+
-+						active_w = "5488";
-+						active_h = "4112";
-+						pixel_t = "bayer_bggr";
-+						csi_pixel_bit_depth = "4";
-+						readout_orientation = "0";
-+						line_length = "5488";
-+						inherent_gain = "1";
-+						mclk_multiplier = "31.25";
-+						pix_clk_hz = "750000000";
-+
-+						gain_factor = "16";
-+						framerate_factor = "1000000";
-+						exposure_factor = "1000000";
-+						min_gain_val = "16"; /* 1.0 */
-+						max_gain_val = "256"; /* 16.0 */
-+						step_gain_val = "1"; /* 0.125 */
-+						min_hdr_ratio = "1";
-+						max_hdr_ratio = "64";
-+						min_framerate = "1500000"; /* 1.5 */
-+						max_framerate = "30000000"; /* 30 */
-+						step_framerate = "1";
-+						min_exp_time = "34"; /* us */
-+						max_exp_time = "550385"; /* us */
-+						step_exp_time = "1";
-+					};
-+
-+					ports {
-+						#address-cells = <1>;
-+						#size-cells = <0>;
-+						port@0 {
-+							reg = <0>;
-+							avt_csi2_out0: endpoint {
-+								port-index = <0>;
-+								bus-width = <2>;
-+								remote-endpoint = <&avt_csi2_csi_in0>;
-+							};
-+						};
-+					};
-+				};
-+			};
-+
-+			i2c@3 {
-+				reg = <3>;
-+				i2c-mux,deselect-on-exit;
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+
-+				avt_csi2@3c {
-+					compatible = "alliedvision,avt_csi2";
-+					/* I2C device address */
-+					reg = <0x3c>;
-+
-+					status = "okay";
-+
-+					/* V4L2 device node location */
-+					devnode = "video1";
-+
-+					mode0 {
-+						num_lanes = "4";
-+						tegra_sinterface = "serial_c";
-+						discontinuous_clk = "no";
-+						cil_settletime = "0";
-+						embedded_metadata_height = "0";
-+
-+						/* not verified: */
-+						mclk_khz = "24000";
-+						phy_mode = "DPHY";
-+						dpcm_enable = "false";
-+
-+						csi_pixel_bit_depth = "4";
-+						active_w = "5488";
-+						active_h = "4112";
-+						pixel_t = "bayer_bggr";
-+						readout_orientation = "0";
-+						line_length = "5488";
-+						inherent_gain = "1";
-+						mclk_multiplier = "31.25";
-+						pix_clk_hz = "750000000";
-+
-+						gain_factor = "16";
-+						framerate_factor = "1000000";
-+						exposure_factor = "1000000";
-+						min_gain_val = "16"; /* 1.0 */
-+						max_gain_val = "256"; /* 16.0 */
-+						step_gain_val = "1"; /* 0.125 */
-+						min_hdr_ratio = "1";
-+						max_hdr_ratio = "64";
-+						min_framerate = "1500000"; /* 1.5 */
-+						max_framerate = "30000000"; /* 30 */
-+						step_framerate = "1";
-+						min_exp_time = "34"; /* us */
-+						max_exp_time = "550385"; /* us */
-+						step_exp_time = "1";
-+					};
-+
-+					ports {
-+						#address-cells = <1>;
-+						#size-cells = <0>;
-+						port@0 {
-+							reg = <0>;
-+							avt_csi2_out1: endpoint {
-+								status = "okay";
-+								port-index = <4>;
-+								bus-width = <2>;
-+								remote-endpoint = <&avt_csi2_csi_in1>;
-+							};
-+						};
-+					};
-+				};
-+			};
 +		};
 +	};
 +
@@ -1247,354 +1001,53 @@ index 000000000..e4723713b
 +		modules {
 +			cam_module0: module0 {
 +				badge = "avt_csi2";
-+				position = "front";
++				position = "topright";
 +				orientation = "1";
 +				cam_module0_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 31-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
++				};
++			};
++			cam_module1: module1 {
++				badge = "avt_csi2";
++				position = "bottomright";
++				orientation = "1";
++				cam_module1_drivernode0: drivernode0 {
 +					pcl_id = "v4l2_sensor";
 +					devname = "avt_csi2 32-003C";
 +					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
 +				};
 +			};
-+			cam_module1: module1 {
++			cam_module2: module2 {
 +				badge = "avt_csi2";
-+				position = "rear";
++				position = "bottomleft";
 +				orientation = "1";
-+				cam_module1_drivernode0: drivernode0 {
++				cam_module2_drivernode0: drivernode0 {
 +					pcl_id = "v4l2_sensor";
 +					devname = "avt_csi2 33-003C";
 +					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@3/avt_csi2@3c";
 +				};
 +			};
-+		};
-+	};
-+};
-\ No newline at end of file
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi
-new file mode 100644
-index 000000000..92b665674
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi
-@@ -0,0 +1,315 @@
-+/*
-+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-+ */
-+#include <dt-bindings/media/camera.h>
-+
-+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
-+
-+/ {
-+	tegra-capture-vi  {
-+			num-channels = <2>;
-+			ports {
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+				vi_port0: port@0 {
-+					reg = <0>;
-+					avt_csi2_vi_in0: endpoint {
-+						port-index = <0>;
-+						bus-width = <4>;
-+						remote-endpoint = <&avt_csi2_csi_out0>;
-+					};
-+				};
-+				vi_port1: port@1 {
-+					reg = <1>;
-+					avt_csi2_vi_in1: endpoint {
-+						port-index = <2>;
-+						bus-width = <4>;
-+						remote-endpoint = <&avt_csi2_csi_out1>;
-+					};
-+				};
-+			};
-+		};
-+	host1x@13e00000 {
-+		nvcsi@15a00000 {
-+			num-channels = <2>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			csi_chan0: channel@0 {
-+				reg = <0>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan0_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in0: endpoint@0 {
-+							port-index = <0>;
-+							bus-width = <4>;
-+							remote-endpoint = <&avt_csi2_out0>;
-+						};
-+					};
-+					csi_chan0_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out0: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in0>;
-+						};
-+					};
-+				};
-+			};
-+			csi_chan1: channel@1 {
-+				reg = <1>;
-+				ports {
-+					#address-cells = <1>;
-+					#size-cells = <0>;
-+					csi_chan1_port0: port@0 {
-+						reg = <0>;
-+						avt_csi2_csi_in1: endpoint@0 {
-+							port-index = <2>;
-+							bus-width = <4>;
-+							remote-endpoint = <&avt_csi2_out1>;
-+						};
-+					};
-+					csi_chan1_port1: port@1 {
-+						reg = <1>;
-+						avt_csi2_csi_out1: endpoint@1 {
-+							remote-endpoint = <&avt_csi2_vi_in1>;
-+						};
-+					};
-+				};
-+			};
-+		};
-+	};
-+
-+	i2c@3180000 {
-+		avt_pca9547: avt_pca9547@70 {
-+			compatible = "nxp,pca9547";
-+			status = "okay";
-+			reg = <0x70>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			vcc-supply = <&battery_reg>;
-+			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
-+
-+			i2c@1 {
-+				reg = <1>;
-+				i2c-mux,deselect-on-exit;
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+
-+				avt_csi2@3c {
-+					compatible = "alliedvision,avt_csi2";
-+					/* I2C device address */
-+					reg = <0x3c>;
-+
-+					status = "okay";
-+
-+					/* V4L2 device node location */
-+					devnode = "video0";
-+
-+					mode0 {
-+						num_lanes = "4";
-+						tegra_sinterface = "serial_e";
-+						discontinuous_clk = "no";
-+						cil_settletime = "0";
-+						embedded_metadata_height = "0";
-+
-+						/* not verified: */
-+						mclk_khz = "24000";
-+						phy_mode = "DPHY";
-+						dpcm_enable = "false";
-+
-+						csi_pixel_bit_depth = "4";
-+						active_w = "5488";
-+						active_h = "4112";
-+						pixel_t = "bayer_bggr";
-+						readout_orientation = "0";
-+						line_length = "5488";
-+						inherent_gain = "1";
-+						mclk_multiplier = "31.25";
-+						pix_clk_hz = "750000000";
-+
-+						gain_factor = "16";
-+						framerate_factor = "1000000";
-+						exposure_factor = "1000000";
-+						min_gain_val = "16"; /* 1.0 */
-+						max_gain_val = "256"; /* 16.0 */
-+						step_gain_val = "1"; /* 0.125 */
-+						min_hdr_ratio = "1";
-+						max_hdr_ratio = "64";
-+						min_framerate = "1500000"; /* 1.5 */
-+						max_framerate = "30000000"; /* 30 */
-+						step_framerate = "1";
-+						min_exp_time = "34"; /* us */
-+						max_exp_time = "550385"; /* us */
-+						step_exp_time = "1";
-+					};
-+
-+					ports {
-+						#address-cells = <1>;
-+						#size-cells = <0>;
-+						port@0 {
-+							reg = <0>;
-+							avt_csi2_out1: endpoint {
-+								status = "okay";
-+								port-index = <2>;
-+								bus-width = <4>;
-+								remote-endpoint = <&avt_csi2_csi_in1>;
-+							};
-+						};
-+					};
-+				};
-+			};
-+
-+			i2c@2 {
-+				reg = <2>;
-+				i2c-mux,deselect-on-exit;
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+				avt_csi2@3c {
-+					compatible = "alliedvision,avt_csi2";
-+					/* I2C device address */
-+					reg = <0x3c>;
-+
-+					status = "okay";
-+
-+					/* V4L2 device node location */
-+					devnode = "video1";
-+
-+					mode0 {
-+						num_lanes = "4";
-+						tegra_sinterface = "serial_a";
-+						discontinuous_clk = "no";
-+						cil_settletime = "0";
-+						embedded_metadata_height = "0";
-+
-+						/* not verified: */
-+						mclk_khz = "24000";
-+						phy_mode = "DPHY";
-+						dpcm_enable = "false";
-+
-+						active_w = "5488";
-+						active_h = "4112";
-+						pixel_t = "bayer_bggr";
-+						csi_pixel_bit_depth = "4";
-+						readout_orientation = "0";
-+						line_length = "5488";
-+						inherent_gain = "1";
-+						mclk_multiplier = "31.25";
-+						pix_clk_hz = "750000000";
-+
-+						gain_factor = "16";
-+						framerate_factor = "1000000";
-+						exposure_factor = "1000000";
-+						min_gain_val = "16"; /* 1.0 */
-+						max_gain_val = "256"; /* 16.0 */
-+						step_gain_val = "1"; /* 0.125 */
-+						min_hdr_ratio = "1";
-+						max_hdr_ratio = "64";
-+						min_framerate = "1500000"; /* 1.5 */
-+						max_framerate = "30000000"; /* 30 */
-+						step_framerate = "1";
-+						min_exp_time = "34"; /* us */
-+						max_exp_time = "550385"; /* us */
-+						step_exp_time = "1";
-+					};
-+
-+					ports {
-+						#address-cells = <1>;
-+						#size-cells = <0>;
-+						port@0 {
-+							reg = <0>;
-+							avt_csi2_out0: endpoint {
-+								port-index = <0>;
-+								bus-width = <4>;
-+								remote-endpoint = <&avt_csi2_csi_in0>;
-+							};
-+						};
-+					};
-+				};
-+			};
-+		};
-+	};
-+
-+	tcp: tegra-camera-platform {
-+		compatible = "nvidia, tegra-camera-platform";
-+		/**
-+		* Physical settings to calculate max ISO BW
-+		*
-+		* num_csi_lanes = <>;
-+		* Total number of CSI lanes when all cameras are active
-+		*
-+		* max_lane_speed = <>;
-+		* Max lane speed in Kbit/s
-+		*
-+		* min_bits_per_pixel = <>;
-+		* Min bits per pixel
-+		*
-+		* vi_peak_byte_per_pixel = <>;
-+		* Max byte per pixel for the VI ISO case
-+		*
-+		* vi_bw_margin_pct = <>;
-+		* Vi bandwidth margin in percentage
-+		*
-+		* max_pixel_rate = <>;
-+		* Max pixel rate in Kpixel/s for the ISP ISO case
-+		*
-+		* isp_peak_byte_per_pixel = <>;
-+		* Max byte per pixel for the ISP ISO case
-+		*
-+		* isp_bw_margin_pct = <>;
-+		* Isp bandwidth margin in percentage
-+		*/
-+		num_csi_lanes = <8>;
-+		max_lane_speed = <1500000>;
-+		min_bits_per_pixel = <8>;
-+		vi_peak_byte_per_pixel = <2>;
-+		vi_bw_margin_pct = <25>;
-+		max_pixel_rate = <160000>;
-+		isp_peak_byte_per_pixel = <5>;
-+		isp_bw_margin_pct = <25>;
-+
-+		/**
-+		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
-+		 * The first part is the camera_board_id for the module; if the module is in a FFD
-+		 * platform, then use the platform name for this part.
-+		 * The second part contains the position of the module, ex. "rear" or "front".
-+		 * The third part contains the last 6 characters of a part number which is found
-+		 * in the module's specsheet from the vendor.
-+		 */
-+		modules {
-+			cam_module0: module0 {
++			cam_module3: module3 {
 +				badge = "avt_csi2";
-+				position = "front";
++				position = "topleft";
 +				orientation = "1";
-+				cam_module0_drivernode0: drivernode0 {
++				cam_module3_drivernode0: drivernode0 {
 +					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 31-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
-+				};
-+			};
-+			cam_module1: module1 {
-+				badge = "avt_csi2";
-+				position = "rear";
-+				orientation = "1";
-+				cam_module1_drivernode0: drivernode0 {
-+					pcl_id = "v4l2_sensor";
-+					devname = "avt_csi2 32-003C";
-+					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
++					devname = "avt_csi2 30-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@0/avt_csi2@3c";
 +				};
 +			};
 +		};
 +	};
 +};
 +
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-4lane.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-4lane.dts
 new file mode 100644
-index 000000000..3c10cc463
+index 000000000..5048e35fd
 --- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-4lane.dts
 @@ -0,0 +1,34 @@
 +/*
 + * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
@@ -1614,7 +1067,7 @@ index 000000000..3c10cc463
 +/dts-v1/;
 +#include "common/tegra194-p3668-common.dtsi"
 +#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-4lane.dtsi"
 +
 +/ {
 +	nvidia,dtsfilename = __FILE__;
@@ -1630,11 +1083,11 @@ index 000000000..3c10cc463
 +		/delete-property/ mmc0;
 +	};
 +};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro.dts
 new file mode 100644
-index 000000000..73207afa1
+index 000000000..ea33c1b4a
 --- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro.dts
 @@ -0,0 +1,34 @@
 +/*
 + * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
@@ -1654,7 +1107,7 @@ index 000000000..73207afa1
 +/dts-v1/;
 +#include "common/tegra194-p3668-common.dtsi"
 +#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro.dtsi"
 +
 +/ {
 +	nvidia,dtsfilename = __FILE__;
@@ -1670,12 +1123,12 @@ index 000000000..73207afa1
 +		/delete-property/ mmc0;
 +	};
 +};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-4lane.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-4lane.dts
 new file mode 100644
-index 000000000..c26437032
+index 000000000..97690a724
 --- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts
-@@ -0,0 +1,34 @@
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-4lane.dts
+@@ -0,0 +1,32 @@
 +/*
 + * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
 + *
@@ -1694,87 +1147,7 @@ index 000000000..c26437032
 +/dts-v1/;
 +#include "common/tegra194-p3668-common.dtsi"
 +#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi"
-+
-+/ {
-+	nvidia,dtsfilename = __FILE__;
-+	nvidia,dtbbuildtime = __DATE__, __TIME__;
-+
-+	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3509-0000+p3668-0000", "nvidia,tegra194";
-+
-+	sdhci@3460000 {
-+		status = "disabled";
-+	};
-+
-+	aliases {
-+		/delete-property/ mmc0;
-+	};
-+};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts
-new file mode 100644
-index 000000000..1ee110288
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts
-@@ -0,0 +1,34 @@
-+/*
-+ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
-+ *
-+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; version 2 of the License.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ */
-+
-+/dts-v1/;
-+#include "common/tegra194-p3668-common.dtsi"
-+#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi"
-+
-+/ {
-+	nvidia,dtsfilename = __FILE__;
-+	nvidia,dtbbuildtime = __DATE__, __TIME__;
-+
-+	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3509-0000+p3668-0000", "nvidia,tegra194";
-+
-+	sdhci@3460000 {
-+		status = "disabled";
-+	};
-+
-+	aliases {
-+		/delete-property/ mmc0;
-+	};
-+};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts
-new file mode 100644
-index 000000000..fcca17496
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts
-@@ -0,0 +1,31 @@
-+/*
-+ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
-+ *
-+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; version 2 of the License.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ */
-+
-+/dts-v1/;
-+#include "common/tegra194-p3668-common.dtsi"
-+#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-4lane.dtsi"
 +
 +
 +/ {
@@ -1782,16 +1155,17 @@ index 000000000..fcca17496
 +	nvidia,dtbbuildtime = __DATE__, __TIME__;
 +
 +	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
-+
++	
 +	sdhci@3400000 {
 +		status = "disabled";
 +	};
++	
 +};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro.dts
 new file mode 100644
-index 000000000..50bb1e072
+index 000000000..db3724573
 --- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro.dts
 @@ -0,0 +1,31 @@
 +/*
 + * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
@@ -1811,81 +1185,7 @@ index 000000000..50bb1e072
 +/dts-v1/;
 +#include "common/tegra194-p3668-common.dtsi"
 +#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi"
-+
-+
-+/ {
-+	nvidia,dtsfilename = __FILE__;
-+	nvidia,dtbbuildtime = __DATE__, __TIME__;
-+
-+	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
-+
-+	sdhci@3400000 {
-+		status = "disabled";
-+	};
-+};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts
-new file mode 100644
-index 000000000..db8b36941
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts
-@@ -0,0 +1,31 @@
-+/*
-+ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
-+ *
-+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; version 2 of the License.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ */
-+
-+/dts-v1/;
-+#include "common/tegra194-p3668-common.dtsi"
-+#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi"
-+
-+
-+/ {
-+	nvidia,dtsfilename = __FILE__;
-+	nvidia,dtbbuildtime = __DATE__, __TIME__;
-+
-+	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
-+
-+	sdhci@3400000 {
-+		status = "disabled";
-+	};
-+};
-diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts
-new file mode 100644
-index 000000000..bbcfbe73a
---- /dev/null
-+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts
-@@ -0,0 +1,31 @@
-+/*
-+ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
-+ *
-+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; version 2 of the License.
-+ *
-+ * This program is distributed in the hope that it will be useful, but WITHOUT
-+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+ * more details.
-+ */
-+
-+/dts-v1/;
-+#include "common/tegra194-p3668-common.dtsi"
-+#include "common/tegra194-p3509-0000-a00.dtsi"
-+#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro.dtsi"
 +
 +
 +/ {

--- a/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
+++ b/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
@@ -166,7 +166,7 @@ index 000000000..15a67243e
 +					csi_chan0_port0: port@0 {
 +						reg = <0>;
 +						avt_csi2_csi_in0: endpoint@0 {
-+							port-index = <5>;
++							port-index = <6>;
 +							bus-width = <2>;
 +							remote-endpoint = <&avt_csi2_out0>;
 +						};
@@ -690,7 +690,7 @@ index 000000000..38c569d35
 +					csi_chan0_port0: port@0 {
 +						reg = <0>;
 +						avt_csi2_csi_in0: endpoint@0 {
-+							port-index = <5>;
++							port-index = <6>;
 +							bus-width = <2>;
 +							remote-endpoint = <&avt_csi2_out0>;
 +						};

--- a/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
+++ b/linux-patches/jakku-l4t-35.1.0-add-support-for-Antmicro-JNB-rev.1.5.1.patch
@@ -1,0 +1,1903 @@
+From d9dc4f679679ed48d73ba29eb9ccb93007e0f567 Mon Sep 17 00:00:00 2001
+From: Tom Molnar <tom.molnar@csiro.au>
+Date: Mon, 13 Feb 2023 10:11:41 +1000
+Subject: [PATCH] jakku: add support for Antmicro JNB rev.1.5.1 (multiple configurations)
+
+---
+ .../jetson_build/files/bootloader/config      |  16 +
+ .../platform/t19x/jakku/kernel-dts/Makefile   |   8 +
+ ...94-camera-jakku-avt-csi2-antmicro-all.dtsi | 541 ++++++++++++++++++
+ ...amera-jakku-avt-csi2-antmicro-dual-j6.dtsi | 315 ++++++++++
+ ...amera-jakku-avt-csi2-antmicro-dual-j7.dtsi | 314 ++++++++++
+ ...ra-jakku-avt-csi2-antmicro-dual-split.dtsi | 315 ++++++++++
+ ...194-p3668-0000-p3509-0000-antmicro-all.dts |  34 ++
+ ...p3668-0000-p3509-0000-antmicro-dual-j6.dts |  34 ++
+ ...p3668-0000-p3509-0000-antmicro-dual-j7.dts |  34 ++
+ ...68-0000-p3509-0000-antmicro-dual-split.dts |  34 ++
+ ...194-p3668-0001-p3509-0000-antmicro-all.dts |  31 +
+ ...p3668-0001-p3509-0000-antmicro-dual-j6.dts |  31 +
+ ...p3668-0001-p3509-0000-antmicro-dual-j7.dts |  31 +
+ ...68-0001-p3509-0000-antmicro-dual-split.dts |  31 +
+ 14 files changed, 1769 insertions(+)
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts
+ create mode 100644 hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts
+
+diff --git a/avt_build/jetson_build/files/bootloader/config b/avt_build/jetson_build/files/bootloader/config
+index d936d580b..3b960926e 100644
+--- a/avt_build/jetson_build/files/bootloader/config
++++ b/avt_build/jetson_build/files/bootloader/config
+@@ -82,6 +82,22 @@ nx_devkit = BoardDefinition('Jetson Xavier NX devkit', '0x19', '3668', [
+     #NX 16GB
+     Configuration('DevKit', 'tegra194-p3668-0001-p3509-0000-avt.dtb', '0003'),
+ 
++    Configuration('Antmicro All', 'tegra194-p3668-0000-p3509-0000-antmicro-all.dtb', '0000'),
++    Configuration('Antmicro All', 'tegra194-p3668-0001-p3509-0000-antmicro-all.dtb', '0001'),
++    Configuration('Antmicro All', 'tegra194-p3668-0001-p3509-0000-antmicro-all.dtb', '0003'),
++
++    Configuration('Antmicro Dual-J6', 'tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dtb', '0000'),
++    Configuration('Antmicro Dual-J6', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dtb', '0001'),
++    Configuration('Antmicro Dual-J6', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dtb', '0003'),
++
++    Configuration('Antmicro Dual-J7', 'tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dtb', '0000'),
++    Configuration('Antmicro Dual-J7', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dtb', '0001'),
++    Configuration('Antmicro Dual-J7', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dtb', '0003'),
++
++    Configuration('Antmicro Dual-Split', 'tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dtb', '0000'),
++    Configuration('Antmicro Dual-Split', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dtb', '0001'),
++    Configuration('Antmicro Dual-Split', 'tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dtb', '0003'),
++
+     #Configuration('Auvidea JNX30 (beta)', 'tegra194-p3668-all-p3509-0000-auvidea-jnx30.dtb', '0000', beta=True),
+     #Configuration('Auvidea JNX30 (beta)', 'tegra194-p3668-all-p3509-0000-auvidea-jnx30.dtb', '0001', beta=True),
+     #NX 16GB
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile b/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
+index 8e6787ccf..d1429fdbf 100644
+--- a/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
+@@ -11,8 +11,16 @@ endif
+ 
+ dtb-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-all.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dtb
+ dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000-avt.dtb
+ dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-all.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dtb
++dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dtb
+ dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-avt.dtb
+ dtb-$(CONFIG_ARCH_TEGRA_19x_SOC) += tegra194-p3668-all-p3509-0000-kexec.dtb
+ dtbo-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000-hdr40.dtbo
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi
+new file mode 100644
+index 000000000..15a67243e
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi
+@@ -0,0 +1,541 @@
++/*
++ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++#include <dt-bindings/media/camera.h>
++
++#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
++
++/ {
++	tegra-capture-vi  {
++			num-channels = <4>;
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				vi_port0: port@0 {
++					reg = <0>;
++					avt_csi2_vi_in0: endpoint {
++						port-index = <5>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out0>;
++					};
++				};
++
++				vi_port1: port@1 {
++					reg = <1>;
++					avt_csi2_vi_in1: endpoint {
++						port-index = <2>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out1>;
++					};
++				};
++
++				vi_port2: port@2 {
++					reg = <2>;
++					avt_csi2_vi_in2: endpoint {
++						port-index = <0>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out2>;
++					};
++				};
++
++				vi_port3: port@3 {
++					reg = <3>;
++					avt_csi2_vi_in3: endpoint {
++						port-index = <4>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out3>;
++					};
++				};
++			};
++		};
++
++	host1x@13e00000 {
++		nvcsi@15a00000 {
++			num-channels = <4>;
++			
++      #address-cells = <1>;
++			#size-cells = <0>;
++
++			csi_chan0: channel@0 {
++				reg = <0>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan0_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in0: endpoint@0 {
++							port-index = <5>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out0>;
++						};
++					};
++					csi_chan0_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out0: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in0>;
++						};
++					};
++				};
++			};
++
++			csi_chan1: channel@1 {
++				reg = <1>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan1_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in1: endpoint@0 {
++							port-index = <2>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out1>;
++						};
++					};
++					csi_chan1_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out1: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in1>;
++						};
++					};
++				};
++			};
++
++			csi_chan2: channel@2 {
++				reg = <2>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan2_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in2: endpoint@0 {
++							port-index = <0>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out2>;
++						};
++					};
++					csi_chan2_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out2: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in2>;
++						};
++					};
++				};
++			};
++
++			csi_chan3: channel@3 {
++				reg = <3>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan3_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in3: endpoint@0 {
++							port-index = <4>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out3>;
++						};
++					};
++					csi_chan3_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out3: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in3>;
++						};
++					};
++				};
++			};
++
++		};
++	};
++
++	i2c@3180000 {
++		avt_pca9547: avt_pca9547@70 {
++			compatible = "nxp,pca9547";
++			status = "okay";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			vcc-supply = <&battery_reg>;
++			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++
++			i2c@0 {
++				reg = <0>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video0";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_g";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						csi_pixel_bit_depth = "4";
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out0: endpoint {
++								status = "okay";
++								port-index = <5>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in0>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c@1 {
++				reg = <1>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video1";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_e";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						csi_pixel_bit_depth = "4";
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out1: endpoint {
++								status = "okay";
++								port-index = <2>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in1>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c@2 {
++				reg = <2>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video2";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_a";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out2: endpoint {
++								port-index = <0>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in2>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c@3 {
++				reg = <3>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video3";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_c";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out3: endpoint {
++								port-index = <4>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in3>;
++							};
++						};
++					};
++				};
++			};
++		};
++	};
++
++	tcp: tegra-camera-platform {
++		compatible = "nvidia, tegra-camera-platform";
++		/**
++		* Physical settings to calculate max ISO BW
++		*
++		* num_csi_lanes = <>;
++		* Total number of CSI lanes when all cameras are active
++		*
++		* max_lane_speed = <>;
++		* Max lane speed in Kbit/s
++		*
++		* min_bits_per_pixel = <>;
++		* Min bits per pixel
++		*
++		* vi_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the VI ISO case
++		*
++		* vi_bw_margin_pct = <>;
++		* Vi bandwidth margin in percentage
++		*
++		* max_pixel_rate = <>;
++		* Max pixel rate in Kpixel/s for the ISP ISO case
++		*
++		* isp_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the ISP ISO case
++		*
++		* isp_bw_margin_pct = <>;
++		* Isp bandwidth margin in percentage
++		*/
++		num_csi_lanes = <8>;
++		max_lane_speed = <1500000>;
++		min_bits_per_pixel = <8>;
++		vi_peak_byte_per_pixel = <2>;
++		vi_bw_margin_pct = <25>;
++		max_pixel_rate = <160000>;
++		isp_peak_byte_per_pixel = <5>;
++		isp_bw_margin_pct = <25>;
++
++		/**
++		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
++		 * The first part is the camera_board_id for the module; if the module is in a FFD
++		 * platform, then use the platform name for this part.
++		 * The second part contains the position of the module, ex. "rear" or "front".
++		 * The third part contains the last 6 characters of a part number which is found
++		 * in the module's specsheet from the vendor.
++		 */
++		modules {
++			cam_module0: module0 {
++				badge = "avt_csi2";
++				position = "topleft";
++				orientation = "1";
++				cam_module0_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 30-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@0/avt_csi2@3c";
++				};
++			};
++			cam_module1: module1 {
++				badge = "avt_csi2";
++				position = "topright";
++				orientation = "1";
++				cam_module1_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 31-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
++				};
++			};
++			cam_module2: module2 {
++				badge = "avt_csi2";
++				position = "bottomright";
++				orientation = "1";
++				cam_module2_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 32-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
++				};
++			};
++			cam_module3: module3 {
++				badge = "avt_csi2";
++				position = "bottomleft";
++				orientation = "1";
++				cam_module3_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 33-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@3/avt_csi2@3c";
++				};
++			};
++		};
++	};
++};
++
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi
+new file mode 100644
+index 000000000..38c569d35
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi
+@@ -0,0 +1,315 @@
++/*
++ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++#include <dt-bindings/media/camera.h>
++
++#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
++
++/ {
++	tegra-capture-vi  {
++			num-channels = <2>;
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++				vi_port0: port@0 {
++					reg = <0>;
++					avt_csi2_vi_in0: endpoint {
++						port-index = <5>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out0>;
++					};
++				};
++				vi_port1: port@1 {
++					reg = <1>;
++					avt_csi2_vi_in1: endpoint {
++						port-index = <2>;
++						bus-width = <2>;
++						remote-endpoint = <&avt_csi2_csi_out1>;
++					};
++				};
++			};
++		};
++	host1x@13e00000 {
++		nvcsi@15a00000 {
++			num-channels = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			csi_chan0: channel@0 {
++				reg = <0>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan0_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in0: endpoint@0 {
++							port-index = <5>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out0>;
++						};
++					};
++					csi_chan0_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out0: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in0>;
++						};
++					};
++				};
++			};
++			csi_chan1: channel@1 {
++				reg = <1>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan1_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in1: endpoint@0 {
++							port-index = <2>;
++							bus-width = <2>;
++							remote-endpoint = <&avt_csi2_out1>;
++						};
++					};
++					csi_chan1_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out1: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in1>;
++						};
++					};
++				};
++			};
++		};
++	};
++
++	i2c@3180000 {
++		avt_pca9547: avt_pca9547@70 {
++			compatible = "nxp,pca9547";
++			status = "okay";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			vcc-supply = <&battery_reg>;
++			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++
++				i2c@0 {
++				reg = <0>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video0";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_g";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out0: endpoint {
++								port-index = <5>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in0>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c@1 {
++				reg = <1>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video1";
++
++					mode0 {
++						num_lanes = "2";
++						tegra_sinterface = "serial_e";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						csi_pixel_bit_depth = "4";
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out1: endpoint {
++								status = "okay";
++								port-index = <2>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in1>;
++							};
++						};
++					};
++				};
++			};
++		};
++	};
++
++	tcp: tegra-camera-platform {
++		compatible = "nvidia, tegra-camera-platform";
++		/**
++		* Physical settings to calculate max ISO BW
++		*
++		* num_csi_lanes = <>;
++		* Total number of CSI lanes when all cameras are active
++		*
++		* max_lane_speed = <>;
++		* Max lane speed in Kbit/s
++		*
++		* min_bits_per_pixel = <>;
++		* Min bits per pixel
++		*
++		* vi_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the VI ISO case
++		*
++		* vi_bw_margin_pct = <>;
++		* Vi bandwidth margin in percentage
++		*
++		* max_pixel_rate = <>;
++		* Max pixel rate in Kpixel/s for the ISP ISO case
++		*
++		* isp_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the ISP ISO case
++		*
++		* isp_bw_margin_pct = <>;
++		* Isp bandwidth margin in percentage
++		*/
++		num_csi_lanes = <4>;
++		max_lane_speed = <1500000>;
++		min_bits_per_pixel = <8>;
++		vi_peak_byte_per_pixel = <2>;
++		vi_bw_margin_pct = <25>;
++		max_pixel_rate = <160000>;
++		isp_peak_byte_per_pixel = <5>;
++		isp_bw_margin_pct = <25>;
++
++		/**
++		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
++		 * The first part is the camera_board_id for the module; if the module is in a FFD
++		 * platform, then use the platform name for this part.
++		 * The second part contains the position of the module, ex. "rear" or "front".
++		 * The third part contains the last 6 characters of a part number which is found
++		 * in the module's specsheet from the vendor.
++		 */
++		modules {
++			cam_module0: module0 {
++				badge = "avt_csi2";
++				position = "front";
++				orientation = "1";
++				cam_module0_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 30-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@0/avt_csi2@3c";
++				};
++			};
++			cam_module1: module1 {
++				badge = "avt_csi2";
++				position = "rear";
++				orientation = "1";
++				cam_module1_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 31-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
++				};
++			};
++		};
++	};
++};
++
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi
+new file mode 100644
+index 000000000..e4723713b
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi
+@@ -0,0 +1,314 @@
++/*
++ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++#include <dt-bindings/media/camera.h>
++
++#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
++
++/ {
++	tegra-capture-vi  {
++			num-channels = <2>;
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++				vi_port0: port@0 {
++					reg = <0>;
++					avt_csi2_vi_in0: endpoint {
++						port-index = <0>;
++						bus-width = <4>;
++						remote-endpoint = <&avt_csi2_csi_out0>;
++					};
++				};
++				vi_port1: port@1 {
++					reg = <1>;
++					avt_csi2_vi_in1: endpoint {
++						port-index = <4>;
++						bus-width = <4>;
++						remote-endpoint = <&avt_csi2_csi_out1>;
++					};
++				};
++			};
++		};
++	host1x@13e00000 {
++		nvcsi@15a00000 {
++			num-channels = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			csi_chan0: channel@0 {
++				reg = <0>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan0_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in0: endpoint@0 {
++							port-index = <0>;
++							bus-width = <4>;
++							remote-endpoint = <&avt_csi2_out0>;
++						};
++					};
++					csi_chan0_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out0: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in0>;
++						};
++					};
++				};
++			};
++			csi_chan1: channel@1 {
++				reg = <1>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan1_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in1: endpoint@0 {
++							port-index = <4>;
++							bus-width = <4>;
++							remote-endpoint = <&avt_csi2_out1>;
++						};
++					};
++					csi_chan1_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out1: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in1>;
++						};
++					};
++				};
++			};
++		};
++	};
++
++	i2c@3180000 {
++		avt_pca9547: avt_pca9547@70 {
++			compatible = "nxp,pca9547";
++			status = "okay";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			vcc-supply = <&battery_reg>;
++			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++
++				i2c@2 {
++				reg = <2>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video0";
++
++					mode0 {
++						num_lanes = "4";
++						tegra_sinterface = "serial_a";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out0: endpoint {
++								port-index = <0>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in0>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c@3 {
++				reg = <3>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video1";
++
++					mode0 {
++						num_lanes = "4";
++						tegra_sinterface = "serial_c";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						csi_pixel_bit_depth = "4";
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out1: endpoint {
++								status = "okay";
++								port-index = <4>;
++								bus-width = <2>;
++								remote-endpoint = <&avt_csi2_csi_in1>;
++							};
++						};
++					};
++				};
++			};
++		};
++	};
++
++	tcp: tegra-camera-platform {
++		compatible = "nvidia, tegra-camera-platform";
++		/**
++		* Physical settings to calculate max ISO BW
++		*
++		* num_csi_lanes = <>;
++		* Total number of CSI lanes when all cameras are active
++		*
++		* max_lane_speed = <>;
++		* Max lane speed in Kbit/s
++		*
++		* min_bits_per_pixel = <>;
++		* Min bits per pixel
++		*
++		* vi_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the VI ISO case
++		*
++		* vi_bw_margin_pct = <>;
++		* Vi bandwidth margin in percentage
++		*
++		* max_pixel_rate = <>;
++		* Max pixel rate in Kpixel/s for the ISP ISO case
++		*
++		* isp_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the ISP ISO case
++		*
++		* isp_bw_margin_pct = <>;
++		* Isp bandwidth margin in percentage
++		*/
++		num_csi_lanes = <8>;
++		max_lane_speed = <1500000>;
++		min_bits_per_pixel = <8>;
++		vi_peak_byte_per_pixel = <2>;
++		vi_bw_margin_pct = <25>;
++		max_pixel_rate = <160000>;
++		isp_peak_byte_per_pixel = <5>;
++		isp_bw_margin_pct = <25>;
++
++		/**
++		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
++		 * The first part is the camera_board_id for the module; if the module is in a FFD
++		 * platform, then use the platform name for this part.
++		 * The second part contains the position of the module, ex. "rear" or "front".
++		 * The third part contains the last 6 characters of a part number which is found
++		 * in the module's specsheet from the vendor.
++		 */
++		modules {
++			cam_module0: module0 {
++				badge = "avt_csi2";
++				position = "front";
++				orientation = "1";
++				cam_module0_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 32-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
++				};
++			};
++			cam_module1: module1 {
++				badge = "avt_csi2";
++				position = "rear";
++				orientation = "1";
++				cam_module1_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 33-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@3/avt_csi2@3c";
++				};
++			};
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi
+new file mode 100644
+index 000000000..92b665674
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi
+@@ -0,0 +1,315 @@
++/*
++ * Copyright (c) 2018-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++#include <dt-bindings/media/camera.h>
++
++#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
++
++/ {
++	tegra-capture-vi  {
++			num-channels = <2>;
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++				vi_port0: port@0 {
++					reg = <0>;
++					avt_csi2_vi_in0: endpoint {
++						port-index = <0>;
++						bus-width = <4>;
++						remote-endpoint = <&avt_csi2_csi_out0>;
++					};
++				};
++				vi_port1: port@1 {
++					reg = <1>;
++					avt_csi2_vi_in1: endpoint {
++						port-index = <2>;
++						bus-width = <4>;
++						remote-endpoint = <&avt_csi2_csi_out1>;
++					};
++				};
++			};
++		};
++	host1x@13e00000 {
++		nvcsi@15a00000 {
++			num-channels = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			csi_chan0: channel@0 {
++				reg = <0>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan0_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in0: endpoint@0 {
++							port-index = <0>;
++							bus-width = <4>;
++							remote-endpoint = <&avt_csi2_out0>;
++						};
++					};
++					csi_chan0_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out0: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in0>;
++						};
++					};
++				};
++			};
++			csi_chan1: channel@1 {
++				reg = <1>;
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					csi_chan1_port0: port@0 {
++						reg = <0>;
++						avt_csi2_csi_in1: endpoint@0 {
++							port-index = <2>;
++							bus-width = <4>;
++							remote-endpoint = <&avt_csi2_out1>;
++						};
++					};
++					csi_chan1_port1: port@1 {
++						reg = <1>;
++						avt_csi2_csi_out1: endpoint@1 {
++							remote-endpoint = <&avt_csi2_vi_in1>;
++						};
++					};
++				};
++			};
++		};
++	};
++
++	i2c@3180000 {
++		avt_pca9547: avt_pca9547@70 {
++			compatible = "nxp,pca9547";
++			status = "okay";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			vcc-supply = <&battery_reg>;
++			force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++
++			i2c@1 {
++				reg = <1>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video0";
++
++					mode0 {
++						num_lanes = "4";
++						tegra_sinterface = "serial_e";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						csi_pixel_bit_depth = "4";
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out1: endpoint {
++								status = "okay";
++								port-index = <2>;
++								bus-width = <4>;
++								remote-endpoint = <&avt_csi2_csi_in1>;
++							};
++						};
++					};
++				};
++			};
++
++			i2c@2 {
++				reg = <2>;
++				i2c-mux,deselect-on-exit;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				avt_csi2@3c {
++					compatible = "alliedvision,avt_csi2";
++					/* I2C device address */
++					reg = <0x3c>;
++
++					status = "okay";
++
++					/* V4L2 device node location */
++					devnode = "video1";
++
++					mode0 {
++						num_lanes = "4";
++						tegra_sinterface = "serial_a";
++						discontinuous_clk = "no";
++						cil_settletime = "0";
++						embedded_metadata_height = "0";
++
++						/* not verified: */
++						mclk_khz = "24000";
++						phy_mode = "DPHY";
++						dpcm_enable = "false";
++
++						active_w = "5488";
++						active_h = "4112";
++						pixel_t = "bayer_bggr";
++						csi_pixel_bit_depth = "4";
++						readout_orientation = "0";
++						line_length = "5488";
++						inherent_gain = "1";
++						mclk_multiplier = "31.25";
++						pix_clk_hz = "750000000";
++
++						gain_factor = "16";
++						framerate_factor = "1000000";
++						exposure_factor = "1000000";
++						min_gain_val = "16"; /* 1.0 */
++						max_gain_val = "256"; /* 16.0 */
++						step_gain_val = "1"; /* 0.125 */
++						min_hdr_ratio = "1";
++						max_hdr_ratio = "64";
++						min_framerate = "1500000"; /* 1.5 */
++						max_framerate = "30000000"; /* 30 */
++						step_framerate = "1";
++						min_exp_time = "34"; /* us */
++						max_exp_time = "550385"; /* us */
++						step_exp_time = "1";
++					};
++
++					ports {
++						#address-cells = <1>;
++						#size-cells = <0>;
++						port@0 {
++							reg = <0>;
++							avt_csi2_out0: endpoint {
++								port-index = <0>;
++								bus-width = <4>;
++								remote-endpoint = <&avt_csi2_csi_in0>;
++							};
++						};
++					};
++				};
++			};
++		};
++	};
++
++	tcp: tegra-camera-platform {
++		compatible = "nvidia, tegra-camera-platform";
++		/**
++		* Physical settings to calculate max ISO BW
++		*
++		* num_csi_lanes = <>;
++		* Total number of CSI lanes when all cameras are active
++		*
++		* max_lane_speed = <>;
++		* Max lane speed in Kbit/s
++		*
++		* min_bits_per_pixel = <>;
++		* Min bits per pixel
++		*
++		* vi_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the VI ISO case
++		*
++		* vi_bw_margin_pct = <>;
++		* Vi bandwidth margin in percentage
++		*
++		* max_pixel_rate = <>;
++		* Max pixel rate in Kpixel/s for the ISP ISO case
++		*
++		* isp_peak_byte_per_pixel = <>;
++		* Max byte per pixel for the ISP ISO case
++		*
++		* isp_bw_margin_pct = <>;
++		* Isp bandwidth margin in percentage
++		*/
++		num_csi_lanes = <8>;
++		max_lane_speed = <1500000>;
++		min_bits_per_pixel = <8>;
++		vi_peak_byte_per_pixel = <2>;
++		vi_bw_margin_pct = <25>;
++		max_pixel_rate = <160000>;
++		isp_peak_byte_per_pixel = <5>;
++		isp_bw_margin_pct = <25>;
++
++		/**
++		 * The general guideline for naming badge_info contains 3 parts, and is as follows,
++		 * The first part is the camera_board_id for the module; if the module is in a FFD
++		 * platform, then use the platform name for this part.
++		 * The second part contains the position of the module, ex. "rear" or "front".
++		 * The third part contains the last 6 characters of a part number which is found
++		 * in the module's specsheet from the vendor.
++		 */
++		modules {
++			cam_module0: module0 {
++				badge = "avt_csi2";
++				position = "front";
++				orientation = "1";
++				cam_module0_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 31-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@1/avt_csi2@3c";
++				};
++			};
++			cam_module1: module1 {
++				badge = "avt_csi2";
++				position = "rear";
++				orientation = "1";
++				cam_module1_drivernode0: drivernode0 {
++					pcl_id = "v4l2_sensor";
++					devname = "avt_csi2 32-003C";
++					proc-device-tree = "/proc/device-tree/i2c@3180000/avt_pca9547@70/i2c@2/avt_csi2@3c";
++				};
++			};
++		};
++	};
++};
++
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts
+new file mode 100644
+index 000000000..3c10cc463
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-all.dts
+@@ -0,0 +1,34 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi"
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3509-0000+p3668-0000", "nvidia,tegra194";
++
++	sdhci@3460000 {
++		status = "disabled";
++	};
++
++	aliases {
++		/delete-property/ mmc0;
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts
+new file mode 100644
+index 000000000..73207afa1
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j6.dts
+@@ -0,0 +1,34 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi"
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3509-0000+p3668-0000", "nvidia,tegra194";
++
++	sdhci@3460000 {
++		status = "disabled";
++	};
++
++	aliases {
++		/delete-property/ mmc0;
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts
+new file mode 100644
+index 000000000..c26437032
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-j7.dts
+@@ -0,0 +1,34 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi"
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3509-0000+p3668-0000", "nvidia,tegra194";
++
++	sdhci@3460000 {
++		status = "disabled";
++	};
++
++	aliases {
++		/delete-property/ mmc0;
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts
+new file mode 100644
+index 000000000..1ee110288
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0000-p3509-0000-antmicro-dual-split.dts
+@@ -0,0 +1,34 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi"
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3509-0000+p3668-0000", "nvidia,tegra194";
++
++	sdhci@3460000 {
++		status = "disabled";
++	};
++
++	aliases {
++		/delete-property/ mmc0;
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts
+new file mode 100644
+index 000000000..fcca17496
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-all.dts
+@@ -0,0 +1,31 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-all.dtsi"
++
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
++
++	sdhci@3400000 {
++		status = "disabled";
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts
+new file mode 100644
+index 000000000..50bb1e072
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j6.dts
+@@ -0,0 +1,31 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j6.dtsi"
++
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
++
++	sdhci@3400000 {
++		status = "disabled";
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts
+new file mode 100644
+index 000000000..db8b36941
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-j7.dts
+@@ -0,0 +1,31 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-j7.dtsi"
++
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
++
++	sdhci@3400000 {
++		status = "disabled";
++	};
++};
+diff --git a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts
+new file mode 100644
+index 000000000..bbcfbe73a
+--- /dev/null
++++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-0001-p3509-0000-antmicro-dual-split.dts
+@@ -0,0 +1,31 @@
++/*
++ * Top level DTS file for CVM:P3668-0001 and CVB:P3509-0000.
++ *
++ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; version 2 of the License.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ */
++
++/dts-v1/;
++#include "common/tegra194-p3668-common.dtsi"
++#include "common/tegra194-p3509-0000-a00.dtsi"
++#include "common/tegra194-camera-jakku-avt-csi2-antmicro-dual-split.dtsi"
++
++
++/ {
++	nvidia,dtsfilename = __FILE__;
++	nvidia,dtbbuildtime = __DATE__, __TIME__;
++
++	compatible = "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
++
++	sdhci@3400000 {
++		status = "disabled";
++	};
++};
+-- 
+2.25.1
+


### PR DESCRIPTION
This PR resolves #30 by adding a patch to support the AlliedVision driver for the following configuration:
- Jetpack Version: 5.0.2 
- Jetson Module: Xavier NX (both development and production modules)
- Baseboard Rev: 1.5.x

2 configurations are provided in the patch, one supporting all 4 camera outputs at 2-lanes, and another supporting just the 3 outputs capable of 4-lanes. Both configurations were tested using 3 Alvium 1800 series cameras capable of both 2 and 4 lane CSI.

Also included is a guide detailing how to install the modified driver, as well as documenting the process for creating a customised device-tree. Whilst neither perfect nor comprehensive, I thought it useful to provide some documentation for the process, as a way to provide support for others creating their own custom projects based on this open-source design.